### PR TITLE
LoadOrStore: lazy generate level

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,83 @@
+package skipmap
+
+import (
+	"testing"
+
+	"github.com/zhangyunhao116/fastrand"
+)
+
+func BenchmarkLoadOrStoreExist(b *testing.B) {
+	m := NewInt[int]()
+	m.Store(1, 1)
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			m.LoadOrStore(1, 1)
+		}
+	})
+}
+
+func BenchmarkLoadOrStoreLazyExist(b *testing.B) {
+	m := NewInt[int]()
+	m.Store(1, 1)
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			m.LoadOrStoreLazy(1, func() int { return 1 })
+		}
+	})
+}
+
+func BenchmarkLoadOrStoreExistSingle(b *testing.B) {
+	m := NewInt[int]()
+	m.Store(1, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.LoadOrStore(1, 1)
+	}
+}
+
+func BenchmarkLoadOrStoreLazyExistSingle(b *testing.B) {
+	m := NewInt[int]()
+	m.Store(1, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.LoadOrStoreLazy(1, func() int { return 1 })
+	}
+}
+
+func BenchmarkLoadOrStoreRandom(b *testing.B) {
+	m := NewInt[int]()
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			m.LoadOrStore(fastrand.Int(), 1)
+		}
+	})
+}
+
+func BenchmarkLoadOrStoreLazyRandom(b *testing.B) {
+	m := NewInt[int]()
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			m.LoadOrStoreLazy(fastrand.Int(), func() int { return 1 })
+		}
+	})
+}
+
+func BenchmarkLoadOrStoreRandomSingle(b *testing.B) {
+	m := NewInt[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.LoadOrStore(fastrand.Int(), 1)
+	}
+}
+
+func BenchmarkLoadOrStoreLazyRandomSingle(b *testing.B) {
+	m := NewInt[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.LoadOrStoreLazy(fastrand.Int(), func() int { return 1 })
+	}
+}

--- a/gen_func.go
+++ b/gen_func.go
@@ -171,6 +171,7 @@ func (s *FuncMap[keyT, valueT]) Store(key keyT, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *FuncMap[keyT, valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -280,8 +281,11 @@ func (s *FuncMap[keyT, valueT]) LoadAndDelete(key keyT) (value valueT, loaded bo
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *FuncMap[keyT, valueT]) LoadOrStore(key keyT, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*funcnode[keyT, valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*funcnode[keyT, valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -301,6 +305,16 @@ func (s *FuncMap[keyT, valueT]) LoadOrStore(key keyT, value valueT) (actual valu
 			valid                = true
 			pred, succ, prevPred *funcnode[keyT, valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -337,8 +351,11 @@ func (s *FuncMap[keyT, valueT]) LoadOrStore(key keyT, value valueT) (actual valu
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *FuncMap[keyT, valueT]) LoadOrStoreLazy(key keyT, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*funcnode[keyT, valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*funcnode[keyT, valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -358,6 +375,16 @@ func (s *FuncMap[keyT, valueT]) LoadOrStoreLazy(key keyT, f func() valueT) (actu
 			valid                = true
 			pred, succ, prevPred *funcnode[keyT, valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_int.go
+++ b/gen_int.go
@@ -169,6 +169,7 @@ func (s *IntMap[valueT]) Store(key int, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *IntMap[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *IntMap[valueT]) LoadAndDelete(key int) (value valueT, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *IntMap[valueT]) LoadOrStore(key int, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*intnode[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*intnode[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *IntMap[valueT]) LoadOrStore(key int, value valueT) (actual valueT, load
 			valid                = true
 			pred, succ, prevPred *intnode[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *IntMap[valueT]) LoadOrStore(key int, value valueT) (actual valueT, load
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *IntMap[valueT]) LoadOrStoreLazy(key int, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*intnode[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*intnode[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *IntMap[valueT]) LoadOrStoreLazy(key int, f func() valueT) (actual value
 			valid                = true
 			pred, succ, prevPred *intnode[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_int32.go
+++ b/gen_int32.go
@@ -169,6 +169,7 @@ func (s *Int32Map[valueT]) Store(key int32, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *Int32Map[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *Int32Map[valueT]) LoadAndDelete(key int32) (value valueT, loaded bool) 
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Int32Map[valueT]) LoadOrStore(key int32, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int32node[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*int32node[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *Int32Map[valueT]) LoadOrStore(key int32, value valueT) (actual valueT, 
 			valid                = true
 			pred, succ, prevPred *int32node[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *Int32Map[valueT]) LoadOrStore(key int32, value valueT) (actual valueT, 
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Int32Map[valueT]) LoadOrStoreLazy(key int32, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int32node[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*int32node[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *Int32Map[valueT]) LoadOrStoreLazy(key int32, f func() valueT) (actual v
 			valid                = true
 			pred, succ, prevPred *int32node[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_int32desc.go
+++ b/gen_int32desc.go
@@ -169,6 +169,7 @@ func (s *Int32MapDesc[valueT]) Store(key int32, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *Int32MapDesc[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *Int32MapDesc[valueT]) LoadAndDelete(key int32) (value valueT, loaded bo
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Int32MapDesc[valueT]) LoadOrStore(key int32, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int32nodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*int32nodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *Int32MapDesc[valueT]) LoadOrStore(key int32, value valueT) (actual valu
 			valid                = true
 			pred, succ, prevPred *int32nodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *Int32MapDesc[valueT]) LoadOrStore(key int32, value valueT) (actual valu
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Int32MapDesc[valueT]) LoadOrStoreLazy(key int32, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int32nodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*int32nodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *Int32MapDesc[valueT]) LoadOrStoreLazy(key int32, f func() valueT) (actu
 			valid                = true
 			pred, succ, prevPred *int32nodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_int64.go
+++ b/gen_int64.go
@@ -169,6 +169,7 @@ func (s *Int64Map[valueT]) Store(key int64, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *Int64Map[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *Int64Map[valueT]) LoadAndDelete(key int64) (value valueT, loaded bool) 
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Int64Map[valueT]) LoadOrStore(key int64, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int64node[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*int64node[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *Int64Map[valueT]) LoadOrStore(key int64, value valueT) (actual valueT, 
 			valid                = true
 			pred, succ, prevPred *int64node[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *Int64Map[valueT]) LoadOrStore(key int64, value valueT) (actual valueT, 
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Int64Map[valueT]) LoadOrStoreLazy(key int64, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int64node[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*int64node[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *Int64Map[valueT]) LoadOrStoreLazy(key int64, f func() valueT) (actual v
 			valid                = true
 			pred, succ, prevPred *int64node[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_int64desc.go
+++ b/gen_int64desc.go
@@ -169,6 +169,7 @@ func (s *Int64MapDesc[valueT]) Store(key int64, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *Int64MapDesc[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *Int64MapDesc[valueT]) LoadAndDelete(key int64) (value valueT, loaded bo
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Int64MapDesc[valueT]) LoadOrStore(key int64, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int64nodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*int64nodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *Int64MapDesc[valueT]) LoadOrStore(key int64, value valueT) (actual valu
 			valid                = true
 			pred, succ, prevPred *int64nodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *Int64MapDesc[valueT]) LoadOrStore(key int64, value valueT) (actual valu
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Int64MapDesc[valueT]) LoadOrStoreLazy(key int64, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*int64nodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*int64nodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *Int64MapDesc[valueT]) LoadOrStoreLazy(key int64, f func() valueT) (actu
 			valid                = true
 			pred, succ, prevPred *int64nodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_intdesc.go
+++ b/gen_intdesc.go
@@ -169,6 +169,7 @@ func (s *IntMapDesc[valueT]) Store(key int, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *IntMapDesc[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *IntMapDesc[valueT]) LoadAndDelete(key int) (value valueT, loaded bool) 
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *IntMapDesc[valueT]) LoadOrStore(key int, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*intnodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*intnodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *IntMapDesc[valueT]) LoadOrStore(key int, value valueT) (actual valueT, 
 			valid                = true
 			pred, succ, prevPred *intnodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *IntMapDesc[valueT]) LoadOrStore(key int, value valueT) (actual valueT, 
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *IntMapDesc[valueT]) LoadOrStoreLazy(key int, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*intnodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*intnodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *IntMapDesc[valueT]) LoadOrStoreLazy(key int, f func() valueT) (actual v
 			valid                = true
 			pred, succ, prevPred *intnodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_ordereddesc.go
+++ b/gen_ordereddesc.go
@@ -169,6 +169,7 @@ func (s *OrderedMapDesc[keyT, valueT]) Store(key keyT, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *OrderedMapDesc[keyT, valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *OrderedMapDesc[keyT, valueT]) LoadAndDelete(key keyT) (value valueT, lo
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *OrderedMapDesc[keyT, valueT]) LoadOrStore(key keyT, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*orderednodeDesc[keyT, valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*orderednodeDesc[keyT, valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *OrderedMapDesc[keyT, valueT]) LoadOrStore(key keyT, value valueT) (actu
 			valid                = true
 			pred, succ, prevPred *orderednodeDesc[keyT, valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *OrderedMapDesc[keyT, valueT]) LoadOrStore(key keyT, value valueT) (actu
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *OrderedMapDesc[keyT, valueT]) LoadOrStoreLazy(key keyT, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*orderednodeDesc[keyT, valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*orderednodeDesc[keyT, valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *OrderedMapDesc[keyT, valueT]) LoadOrStoreLazy(key keyT, f func() valueT
 			valid                = true
 			pred, succ, prevPred *orderednodeDesc[keyT, valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_stringdesc.go
+++ b/gen_stringdesc.go
@@ -169,6 +169,7 @@ func (s *StringMapDesc[valueT]) Store(key string, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *StringMapDesc[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *StringMapDesc[valueT]) LoadAndDelete(key string) (value valueT, loaded 
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *StringMapDesc[valueT]) LoadOrStore(key string, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*stringnodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*stringnodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *StringMapDesc[valueT]) LoadOrStore(key string, value valueT) (actual va
 			valid                = true
 			pred, succ, prevPred *stringnodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *StringMapDesc[valueT]) LoadOrStore(key string, value valueT) (actual va
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *StringMapDesc[valueT]) LoadOrStoreLazy(key string, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*stringnodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*stringnodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *StringMapDesc[valueT]) LoadOrStoreLazy(key string, f func() valueT) (ac
 			valid                = true
 			pred, succ, prevPred *stringnodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_uint.go
+++ b/gen_uint.go
@@ -169,6 +169,7 @@ func (s *UintMap[valueT]) Store(key uint, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *UintMap[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *UintMap[valueT]) LoadAndDelete(key uint) (value valueT, loaded bool) {
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *UintMap[valueT]) LoadOrStore(key uint, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uintnode[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*uintnode[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *UintMap[valueT]) LoadOrStore(key uint, value valueT) (actual valueT, lo
 			valid                = true
 			pred, succ, prevPred *uintnode[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *UintMap[valueT]) LoadOrStore(key uint, value valueT) (actual valueT, lo
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *UintMap[valueT]) LoadOrStoreLazy(key uint, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uintnode[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*uintnode[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *UintMap[valueT]) LoadOrStoreLazy(key uint, f func() valueT) (actual val
 			valid                = true
 			pred, succ, prevPred *uintnode[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_uint32.go
+++ b/gen_uint32.go
@@ -169,6 +169,7 @@ func (s *Uint32Map[valueT]) Store(key uint32, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *Uint32Map[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *Uint32Map[valueT]) LoadAndDelete(key uint32) (value valueT, loaded bool
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Uint32Map[valueT]) LoadOrStore(key uint32, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint32node[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*uint32node[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *Uint32Map[valueT]) LoadOrStore(key uint32, value valueT) (actual valueT
 			valid                = true
 			pred, succ, prevPred *uint32node[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *Uint32Map[valueT]) LoadOrStore(key uint32, value valueT) (actual valueT
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Uint32Map[valueT]) LoadOrStoreLazy(key uint32, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint32node[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*uint32node[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *Uint32Map[valueT]) LoadOrStoreLazy(key uint32, f func() valueT) (actual
 			valid                = true
 			pred, succ, prevPred *uint32node[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_uint32desc.go
+++ b/gen_uint32desc.go
@@ -169,6 +169,7 @@ func (s *Uint32MapDesc[valueT]) Store(key uint32, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *Uint32MapDesc[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *Uint32MapDesc[valueT]) LoadAndDelete(key uint32) (value valueT, loaded 
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Uint32MapDesc[valueT]) LoadOrStore(key uint32, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint32nodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*uint32nodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *Uint32MapDesc[valueT]) LoadOrStore(key uint32, value valueT) (actual va
 			valid                = true
 			pred, succ, prevPred *uint32nodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *Uint32MapDesc[valueT]) LoadOrStore(key uint32, value valueT) (actual va
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Uint32MapDesc[valueT]) LoadOrStoreLazy(key uint32, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint32nodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*uint32nodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *Uint32MapDesc[valueT]) LoadOrStoreLazy(key uint32, f func() valueT) (ac
 			valid                = true
 			pred, succ, prevPred *uint32nodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_uint64.go
+++ b/gen_uint64.go
@@ -169,6 +169,7 @@ func (s *Uint64Map[valueT]) Store(key uint64, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *Uint64Map[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *Uint64Map[valueT]) LoadAndDelete(key uint64) (value valueT, loaded bool
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *Uint64Map[valueT]) LoadOrStore(key uint64, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint64node[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*uint64node[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *Uint64Map[valueT]) LoadOrStore(key uint64, value valueT) (actual valueT
 			valid                = true
 			pred, succ, prevPred *uint64node[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *Uint64Map[valueT]) LoadOrStore(key uint64, value valueT) (actual valueT
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *Uint64Map[valueT]) LoadOrStoreLazy(key uint64, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uint64node[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*uint64node[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *Uint64Map[valueT]) LoadOrStoreLazy(key uint64, f func() valueT) (actual
 			valid                = true
 			pred, succ, prevPred *uint64node[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/gen_uintdesc.go
+++ b/gen_uintdesc.go
@@ -169,6 +169,7 @@ func (s *UintMapDesc[valueT]) Store(key uint, value valueT) {
 	}
 }
 
+// randomlevel returns a random level and update the highest level if needed.
 func (s *UintMapDesc[valueT]) randomlevel() int {
 	// Generate random level.
 	level := randomLevel()
@@ -278,8 +279,11 @@ func (s *UintMapDesc[valueT]) LoadAndDelete(key uint) (value valueT, loaded bool
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from Store)
 func (s *UintMapDesc[valueT]) LoadOrStore(key uint, value valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uintnodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*uintnodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -299,6 +303,16 @@ func (s *UintMapDesc[valueT]) LoadOrStore(key uint, value valueT) (actual valueT
 			valid                = true
 			pred, succ, prevPred *uintnodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node
@@ -335,8 +349,11 @@ func (s *UintMapDesc[valueT]) LoadOrStore(key uint, value valueT) (actual valueT
 // The loaded result is true if the value was loaded, false if stored.
 // (Modified from LoadOrStore)
 func (s *UintMapDesc[valueT]) LoadOrStoreLazy(key uint, f func() valueT) (actual valueT, loaded bool) {
-	level := s.randomlevel()
-	var preds, succs [maxLevel]*uintnodeDesc[valueT]
+	var (
+		level        int
+		preds, succs [maxLevel]*uintnodeDesc[valueT]
+		hl           = int(atomic.LoadUint64(&s.highestLevel))
+	)
 	for {
 		nodeFound := s.findNode(key, &preds, &succs)
 		if nodeFound != nil { // indicating the key is already in the skip-list
@@ -356,6 +373,16 @@ func (s *UintMapDesc[valueT]) LoadOrStoreLazy(key uint, f func() valueT) (actual
 			valid                = true
 			pred, succ, prevPred *uintnodeDesc[valueT]
 		)
+		if level == 0 {
+			level = s.randomlevel()
+			if level > hl {
+				// If the highest level is updated, usually means that many goroutines
+				// are inserting items. Hopefully we can find a better path in next loop.
+				// TODO(zyh): consider filling the preds if s.header[level].next == nil,
+				// but this strategy's performance is almost the same as the existing method.
+				continue
+			}
+		}
 		for layer := 0; valid && layer < level; layer++ {
 			pred = preds[layer]   // target node's previous node
 			succ = succs[layer]   // target node's next node

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/zhangyunhao116/skipmap
 
 go 1.18
 
-require github.com/zhangyunhao116/fastrand v0.2.1
+require github.com/zhangyunhao116/fastrand v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/zhangyunhao116/fastrand v0.2.1 h1:H5FygwAWuYF7IqJKrdWBbphgHffRC07okNQjT2qbGB4=
 github.com/zhangyunhao116/fastrand v0.2.1/go.mod h1:0v5KgHho0VE6HU192HnY15de/oDS8UrbBChIFjIhBtc=
+github.com/zhangyunhao116/fastrand v0.3.0 h1:7bwe124xcckPulX6fxtr2lFdO2KQqaefdtbk+mqO/Ig=
+github.com/zhangyunhao116/fastrand v0.3.0/go.mod h1:0v5KgHho0VE6HU192HnY15de/oDS8UrbBChIFjIhBtc=


### PR DESCRIPTION
The key problem is that `LoadOrStore` uses an outdated highest level to search the skip list, if the new generated level(says `newLevel`) is bigger than the outdated highest level(says `oldLevel`), all slots in the slices `preds[newLevel-oldLevel:newLevel]` are nil, the function will panic.

The solution is that if the `newLevel` has updated the highest level, we could just continue the loop, and find a new path. At this time, the latest highest level used by the `findNode` is always bigger than or equal to the newLevel, the function won't panic.

```
name                            old time/op  new time/op  delta
LoadOrStoreExist-16             4.43ns ±11%  1.06ns ±21%  -76.05%  (p=0.000 n=10+10)
LoadOrStoreLazyExist-16         4.61ns ± 6%  1.16ns ± 0%  -74.90%  (p=0.000 n=9+7)
LoadOrStoreExistSingle-16       37.5ns ± 6%  10.3ns ± 0%  -72.61%  (p=0.000 n=9+9)
LoadOrStoreLazyExistSingle-16   38.3ns ±11%  10.6ns ± 0%  -72.43%  (p=0.000 n=10+10)
LoadOrStoreRandom-16             209ns ±14%   206ns ±14%     ~     (p=0.684 n=10+10)
LoadOrStoreLazyRandom-16         215ns ± 8%   207ns ± 9%     ~     (p=0.139 n=10+10)
LoadOrStoreRandomSingle-16      1.05µs ± 1%  1.04µs ± 4%     ~     (p=0.535 n=9+10)
LoadOrStoreLazyRandomSingle-16  1.07µs ± 1%  1.06µs ± 3%   -1.09%  (p=0.029 n=8+9)
```