### PR TITLE
stringmap: optimize memory layout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,14 +18,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.18, 1.19, 1.20]
+        go: ['1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
-      
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+            go-version: ${{ matrix.go }}
+            cache: false
+
     - name: CI
       run: |
         go version && go test ./... -race

--- a/gen_func.go
+++ b/gen_func.go
@@ -18,12 +18,12 @@ type FuncMap[keyT any, valueT any] struct {
 }
 
 type funcnode[keyT any, valueT any] struct {
+	key   keyT
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   keyT
-	next  optionalArray // [level]*funcnode
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*funcnode
 }
 
 func newFuncNode[keyT any, valueT any](key keyT, value valueT, level int) *funcnode[keyT, valueT] {

--- a/gen_int.go
+++ b/gen_int.go
@@ -16,12 +16,12 @@ type IntMap[valueT any] struct {
 }
 
 type intnode[valueT any] struct {
+	key   int
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   int
-	next  optionalArray // [level]*intnode
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*intnode
 }
 
 func newIntNode[valueT any](key int, value valueT, level int) *intnode[valueT] {

--- a/gen_int32.go
+++ b/gen_int32.go
@@ -16,12 +16,12 @@ type Int32Map[valueT any] struct {
 }
 
 type int32node[valueT any] struct {
+	key   int32
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   int32
-	next  optionalArray // [level]*int32node
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*int32node
 }
 
 func newInt32Node[valueT any](key int32, value valueT, level int) *int32node[valueT] {

--- a/gen_int32desc.go
+++ b/gen_int32desc.go
@@ -16,12 +16,12 @@ type Int32MapDesc[valueT any] struct {
 }
 
 type int32nodeDesc[valueT any] struct {
+	key   int32
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   int32
-	next  optionalArray // [level]*int32nodeDesc
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*int32nodeDesc
 }
 
 func newInt32NodeDesc[valueT any](key int32, value valueT, level int) *int32nodeDesc[valueT] {

--- a/gen_int64.go
+++ b/gen_int64.go
@@ -16,12 +16,12 @@ type Int64Map[valueT any] struct {
 }
 
 type int64node[valueT any] struct {
+	key   int64
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   int64
-	next  optionalArray // [level]*int64node
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*int64node
 }
 
 func newInt64Node[valueT any](key int64, value valueT, level int) *int64node[valueT] {

--- a/gen_int64desc.go
+++ b/gen_int64desc.go
@@ -16,12 +16,12 @@ type Int64MapDesc[valueT any] struct {
 }
 
 type int64nodeDesc[valueT any] struct {
+	key   int64
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   int64
-	next  optionalArray // [level]*int64nodeDesc
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*int64nodeDesc
 }
 
 func newInt64NodeDesc[valueT any](key int64, value valueT, level int) *int64nodeDesc[valueT] {

--- a/gen_intdesc.go
+++ b/gen_intdesc.go
@@ -16,12 +16,12 @@ type IntMapDesc[valueT any] struct {
 }
 
 type intnodeDesc[valueT any] struct {
+	key   int
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   int
-	next  optionalArray // [level]*intnodeDesc
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*intnodeDesc
 }
 
 func newIntNodeDesc[valueT any](key int, value valueT, level int) *intnodeDesc[valueT] {

--- a/gen_ordered.go
+++ b/gen_ordered.go
@@ -16,12 +16,12 @@ type OrderedMap[keyT ordered, valueT any] struct {
 }
 
 type orderednode[keyT ordered, valueT any] struct {
+	key   keyT
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   keyT
-	next  optionalArray // [level]*orderednode
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*orderednode
 }
 
 func newOrderedNode[keyT ordered, valueT any](key keyT, value valueT, level int) *orderednode[keyT, valueT] {

--- a/gen_ordereddesc.go
+++ b/gen_ordereddesc.go
@@ -16,12 +16,12 @@ type OrderedMapDesc[keyT ordered, valueT any] struct {
 }
 
 type orderednodeDesc[keyT ordered, valueT any] struct {
+	key   keyT
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   keyT
-	next  optionalArray // [level]*orderednodeDesc
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*orderednodeDesc
 }
 
 func newOrderedNodeDesc[keyT ordered, valueT any](key keyT, value valueT, level int) *orderednodeDesc[keyT, valueT] {

--- a/gen_string.go
+++ b/gen_string.go
@@ -16,12 +16,12 @@ type StringMap[valueT any] struct {
 }
 
 type stringnode[valueT any] struct {
+	key   string
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   string
-	next  optionalArray // [level]*stringnode
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*stringnode
 }
 
 func newStringNode[valueT any](key string, value valueT, level int) *stringnode[valueT] {

--- a/gen_stringdesc.go
+++ b/gen_stringdesc.go
@@ -16,12 +16,12 @@ type StringMapDesc[valueT any] struct {
 }
 
 type stringnodeDesc[valueT any] struct {
+	key   string
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   string
-	next  optionalArray // [level]*stringnodeDesc
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*stringnodeDesc
 }
 
 func newStringNodeDesc[valueT any](key string, value valueT, level int) *stringnodeDesc[valueT] {

--- a/gen_uint.go
+++ b/gen_uint.go
@@ -16,12 +16,12 @@ type UintMap[valueT any] struct {
 }
 
 type uintnode[valueT any] struct {
+	key   uint
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   uint
-	next  optionalArray // [level]*uintnode
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*uintnode
 }
 
 func newUintNode[valueT any](key uint, value valueT, level int) *uintnode[valueT] {

--- a/gen_uint32.go
+++ b/gen_uint32.go
@@ -16,12 +16,12 @@ type Uint32Map[valueT any] struct {
 }
 
 type uint32node[valueT any] struct {
+	key   uint32
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   uint32
-	next  optionalArray // [level]*uint32node
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*uint32node
 }
 
 func newUint32Node[valueT any](key uint32, value valueT, level int) *uint32node[valueT] {

--- a/gen_uint32desc.go
+++ b/gen_uint32desc.go
@@ -16,12 +16,12 @@ type Uint32MapDesc[valueT any] struct {
 }
 
 type uint32nodeDesc[valueT any] struct {
+	key   uint32
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   uint32
-	next  optionalArray // [level]*uint32nodeDesc
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*uint32nodeDesc
 }
 
 func newUint32NodeDesc[valueT any](key uint32, value valueT, level int) *uint32nodeDesc[valueT] {

--- a/gen_uint64.go
+++ b/gen_uint64.go
@@ -16,12 +16,12 @@ type Uint64Map[valueT any] struct {
 }
 
 type uint64node[valueT any] struct {
+	key   uint64
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   uint64
-	next  optionalArray // [level]*uint64node
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*uint64node
 }
 
 func newUint64Node[valueT any](key uint64, value valueT, level int) *uint64node[valueT] {

--- a/gen_uint64desc.go
+++ b/gen_uint64desc.go
@@ -16,12 +16,12 @@ type Uint64MapDesc[valueT any] struct {
 }
 
 type uint64nodeDesc[valueT any] struct {
+	key   uint64
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   uint64
-	next  optionalArray // [level]*uint64nodeDesc
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*uint64nodeDesc
 }
 
 func newUint64NodeDesc[valueT any](key uint64, value valueT, level int) *uint64nodeDesc[valueT] {

--- a/gen_uintdesc.go
+++ b/gen_uintdesc.go
@@ -16,12 +16,12 @@ type UintMapDesc[valueT any] struct {
 }
 
 type uintnodeDesc[valueT any] struct {
+	key   uint
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   uint
-	next  optionalArray // [level]*uintnodeDesc
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray // [level]*uintnodeDesc
 }
 
 func newUintNodeDesc[valueT any](key uint, value valueT, level int) *uintnodeDesc[valueT] {

--- a/skipmap.tpl
+++ b/skipmap.tpl
@@ -15,12 +15,12 @@ type {{.StructPrefix}}Map{{.StructSuffix}}{{.TypeParam}} struct {
 }
 
 type {{.StructPrefixLow}}node{{.StructSuffix}}{{.TypeParam}} struct {
+	key   {{.KeyType}}
 	value unsafe.Pointer // *any
 	flags bitflag
-	key   {{.KeyType}}
-	next  optionalArray  // [level]*{{.StructPrefixLow}}node{{.StructSuffix}}
-	mu    sync.Mutex
 	level uint32
+	mu    sync.Mutex
+	next  optionalArray  // [level]*{{.StructPrefixLow}}node{{.StructSuffix}}
 }
 
 func new{{.StructPrefix}}Node{{.StructSuffix}}{{.TypeParam}}(key {{.KeyType}}, value {{.ValueType}}, level int) *{{.StructPrefixLow}}node{{.StructSuffix}}{{.TypeArgument}} {


### PR DESCRIPTION
```
name                                           old alloc/op   new alloc/op   delta
Int64/Store/skipmap-16                            96.0B ± 0%     96.0B ± 0%     ~     (all equal)
Int64/Load50Hits/skipmap-16                       0.00B          0.00B          ~     (all equal)
Int64/30Store70Load/skipmap-16                    28.3B ± 2%     28.3B ± 2%     ~     (p=1.000 n=20+20)
Int64/1Delete9Store90Load/skipmap-16              8.00B ± 0%     8.00B ± 0%     ~     (all equal)
Int64/1Range9Delete90Store900Load/skipmap-16      8.00B ± 0%     8.00B ± 0%     ~     (all equal)
String/Store/skipmap-16                            128B ± 0%      112B ± 0%  -12.50%  (p=0.000 n=20+20)
String/Load50Hits/skipmap-16                      15.0B ± 0%     15.0B ± 0%     ~     (all equal)
String/30Store70Load/skipmap-16                   49.0B ± 0%     44.0B ± 0%  -10.20%  (p=0.000 n=19+20)
String/1Delete9Store90Load/skipmap-16             25.0B ± 0%     24.0B ± 0%   -4.00%  (p=0.000 n=17+20)
String/1Range9Delete90Store900Load/skipmap-16     25.0B ± 0%     24.0B ± 0%   -4.00%  (p=0.000 n=16+20)
```